### PR TITLE
Add Taipan Bounties

### DIFF
--- a/Content.Server/Cargo/Components/StationCargoBountyDatabaseComponent.cs
+++ b/Content.Server/Cargo/Components/StationCargoBountyDatabaseComponent.cs
@@ -9,6 +9,9 @@ namespace Content.Server.Cargo.Components;
 [RegisterComponent]
 public sealed partial class StationCargoBountyDatabaseComponent : Component
 {
+    [DataField("IsTaipan")]
+    public bool IsTaipan = false;
+
     /// <summary>
     /// Maximum amount of bounties a station can have.
     /// </summary>

--- a/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Bounty.cs
@@ -392,7 +392,10 @@ public sealed partial class CargoSystem
         {
             if (component.Bounties.Any(b => b.Bounty == proto.ID))
                 continue;
-            filteredBounties.Add(proto);
+            if (proto.IsTaipan && component.IsTaipan)
+                filteredBounties.Add(proto);
+            if (!proto.IsTaipan && !component.IsTaipan)
+                filteredBounties.Add(proto);
         }
 
         var pool = filteredBounties.Count == 0 ? allBounties : filteredBounties;

--- a/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
+++ b/Content.Shared/Cargo/Prototypes/CargoBountyPrototype.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Whitelist;
+using Content.Shared.Whitelist;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
@@ -15,6 +15,9 @@ public sealed partial class CargoBountyPrototype : IPrototype
     /// <inheritdoc/>
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    [DataField("IsTaipan")]
+    public bool IsTaipan = false;
 
     /// <summary>
     /// The monetary reward for completing the bounty

--- a/Resources/Locale/en-US/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/cargo/bounties.ftl
@@ -138,3 +138,8 @@ bounty-description-microwave-machine-board = Mr. Giggles thought it'd be funny t
 bounty-description-flashes = GREETINGS \[Station] WE REQUIRE 6 FLASHES DUE TO A NORMAL \[TrainingExercise] WITH SECURITY. EVERYTHING IS \[Normal].
 bounty-description-tooth-space-carp = Some lads from "down unda" need some teeth to make their traditional apparel. Send them a few from some space carp.
 bounty-description-tooth-sharkminnow = The chef is claiming that the teeth of sharkminnows are some kind of high-quality knife. I don't know what they're on about, but they want a set. Send it to them.
+
+
+bounty-item-captain-sabre = Captain Sabre
+
+bounty-description-captain-sabre = V NT DURAKI ODNI!

--- a/Resources/Prototypes/Catalog/Bounties/taipan_bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/taipan_bounties.yml
@@ -1,0 +1,65 @@
+- type: cargoBounty
+  id: TaipanBountyBread
+  IsTaipan: true
+  reward: 11111
+  description: bounty-description-captain-sabre
+  entries:
+  - name: bounty-item-captain-sabre
+    amount: 1
+    whitelist:
+      tags:
+      - CaptainSabre
+    blacklist:
+      tags:
+      - Slice
+
+- type: cargoBounty
+  id: TaipanBountyLime
+  IsTaipan: true
+  reward: 11111
+  description: bounty-description-lime
+  idPrefix: SY
+  entries:
+  - name: bounty-item-lime
+    amount: 7
+    whitelist:
+      tags:
+      - Lime
+
+- type: cargoBounty
+  id: TaipanBountyLung
+  IsTaipan: true
+  reward: 11111
+  description: bounty-description-lung
+  entries:
+  - name: bounty-item-lung
+    amount: 3
+    whitelist:
+      components:
+      - PowerCageMedium
+
+- type: cargoBounty
+  id: TaipanBountyMonkeyCube
+  IsTaipan: true
+  reward: 11111
+  description: bounty-description-monkey-cube
+  idPrefix: SY
+  entries:
+  - name: bounty-item-monkey-cube
+    amount: 3
+    whitelist:
+      tags:
+      - ResearchDisk10000
+
+- type: cargoBounty
+  id: TaipanBountyMouse
+  IsTaipan: true
+  reward: 11111
+  description: bounty-description-mouse
+  idPrefix: TP13-
+  entries:
+  - name: bounty-item-mouse
+    amount: 5
+    whitelist:
+      tags:
+      - Mouse

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -11,6 +11,7 @@
     - type: StationBankAccount
     - type: StationCargoOrderDatabase
     - type: StationCargoBountyDatabase
+      IsTaipan: true
 
 - type: entity
   id: BaseStationJobsSpawning


### PR DESCRIPTION
## Описание PR
Добавлены квесты для карго тайпана

## Технические детали
Добавлены новые поля и проверки в системе и компонентах карго квестов. Также добавлен yml файс с примерами заказов.

## Требования
- [Х] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [Х] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl:
- add: Добавлены заказы в карго для тайпана
- tweak: Изменены система и компонент для карго квестов
