### PR TITLE
Add cargo orders for taipan

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/cargo/cargoproduct-categories.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/cargo/cargoproduct-categories.ftl
@@ -14,3 +14,4 @@ cargoproduct-category-name-science = Science
 cargoproduct-category-name-security = Security
 cargoproduct-category-name-service = Service
 cargoproduct-category-name-shuttle = Shuttle
+cargoproduct-category-name-syndicate = Syndicate

--- a/Resources/Prototypes/Catalog/Cargo/cargo_syndicate.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_syndicate.yml
@@ -1,0 +1,29 @@
+- type: cargoProduct
+  id: SArmoryShotgun
+  icon:
+    sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
+    state: icon
+  product: CrateArmoryShotgun
+  cost: 7000
+  category: cargoproduct-category-name-syndicate
+  group: syndicate_market
+
+- type: cargoProduct
+  id: SEngineSingularityGenerator
+  icon:
+    sprite: Structures/Power/Generation/Singularity/generator.rsi
+    state: icon
+  product: CrateEngineeringSingularityGenerator
+  cost: 4000
+  category: cargoproduct-category-name-syndicate
+  group: syndicate_market
+
+- type: cargoProduct
+  id: SEngineSingularityContainment
+  icon:
+    sprite: Structures/Power/Generation/Singularity/containment.rsi
+    state: icon
+  product: CrateEngineeringSingularityContainment
+  cost: 1000
+  category: cargoproduct-category-name-syndicate
+  group: syndicate_market

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -85,6 +85,15 @@
       price: 750
 
 - type: entity
+  parent: CargoRequestComputerCircuitboard
+  id: SyndicateCargoRequestComputerCircuitboard
+  suffix: Taipan
+  description: Used to taipan order supplies and approve requests.
+  components:
+    - type: ComputerBoard
+      prototype: TaipanComputerCargoOrders
+
+- type: entity
   parent: BaseComputerCircuitboard
   id: CargoSaleComputerCircuitboard
   name: cargo sale computer board

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -835,6 +835,24 @@
     - Cargo
 
 - type: entity
+  parent: ComputerCargoOrders
+  id: TaipanComputerCargoOrders
+  suffix: Taipan
+  description: Used to taipan order supplies and approve requests.
+  components:
+  - type: CargoOrderConsole
+    announcementChannel: Syndicate
+    allowedGroups:
+    - syndicate_market
+  - type: ActiveRadio
+    channels:
+    - Syndicate
+  - type: Computer
+    board: SyndicateCargoRequestComputerCircuitboard
+  - type: AccessReader
+    access: [["SyndicateAgent"]]
+
+- type: entity
   id: ComputerCargoBounty
   parent: BaseComputerAiAccess
   name: cargo bounty computer


### PR DESCRIPTION
## Описание PR
Добавлена консоль для заказов для тайпана.

## Технические детали
Добавлены возможность заказов предметов для тайпана.

## Требования
- [ X ] Я прочитал(а) и следую [Рекомендациям по оформлению Pull Request и Changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] Я добавил(а) медиафайлы к этому PR или он не требует демонстрации в игре.

**Список изменений**
:cl:
- add: Добавлена система заказов для карго тайпана.
